### PR TITLE
fix measure in 4.2.2

### DIFF
--- a/library/src/main/java/com/eowise/recyclerview/stickyheaders/StickyHeadersItemDecoration.java
+++ b/library/src/main/java/com/eowise/recyclerview/stickyheaders/StickyHeadersItemDecoration.java
@@ -128,7 +128,7 @@ public class StickyHeadersItemDecoration extends RecyclerView.ItemDecoration {
     private void ensureHeaderLaidOut() {
         if (headerHeight == NO_HEIGHT) {
             int widthSpec = View.MeasureSpec.makeMeasureSpec(parent.getWidth(), View.MeasureSpec.EXACTLY);
-            int heightSpec = View.MeasureSpec.makeMeasureSpec(ViewGroup.LayoutParams.WRAP_CONTENT, View.MeasureSpec.AT_MOST);
+            int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
             headerViewHolder.itemView.measure(widthSpec, heightSpec);
             headerViewHolder.itemView.layout(0, 0, headerViewHolder.itemView.getMeasuredWidth(), headerViewHolder.itemView.getMeasuredHeight());
             headerHeight = headerViewHolder.itemView.getMeasuredHeight();


### PR DESCRIPTION
The measure code breaks in 4.2.2 - at least thats my experience, I got a 5.0 and a 4.2.2 device and onmeasure breaks on the second one.

Turns out that `View.MeasureSpec.makeMeasureSpec(WRAP_CONTENT ...` is wrong
