### PR TITLE
Fix java.lang.IndexOutOfBoundsException: happens after AdapterDataObserver.onChanged()

### DIFF
--- a/library/src/main/java/com/eowise/recyclerview/stickyheaders/HeaderStore.java
+++ b/library/src/main/java/com/eowise/recyclerview/stickyheaders/HeaderStore.java
@@ -70,6 +70,11 @@ public class HeaderStore {
 
     public boolean isHeader(RecyclerView.ViewHolder itemHolder) {
         int itemPosition = RecyclerViewHelper.convertPreLayoutPositionToPostLayout(parent, itemHolder.getPosition());
+        if (isHeaderByItemPosition.size() < itemPosition) {
+            for (int i = 0; i < itemPosition; i++) {
+                isHeaderByItemPosition.add(null);
+            }
+        }
         if (isHeaderByItemPosition.size() <= itemPosition) {
             isHeaderByItemPosition.add(itemPosition, itemPosition == 0 || adapter.getHeaderId(itemPosition) != adapter.getHeaderId(itemPosition - 1));
         }


### PR DESCRIPTION
...er.onChanged() is called)

```
java.lang.IndexOutOfBoundsException: Invalid index 6, size is 0
            at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:255)
            at java.util.ArrayList.add(ArrayList.java:147)
            at com.eowise.recyclerview.stickyheaders.HeaderStore.isHeader(HeaderStore.java:74)
```

Another option would be to use SparseArray instead of ArrayList for isHeaderByItemPosition
