### PR TITLE
Fixed an ArrayOutOfBoundsException in HeaderStore.

### DIFF
--- a/library/src/main/java/com/eowise/recyclerview/stickyheaders/HeaderStore.java
+++ b/library/src/main/java/com/eowise/recyclerview/stickyheaders/HeaderStore.java
@@ -138,6 +138,14 @@ public class HeaderStore {
     public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
         headersViewByHeadersIds.clear();
 
+        int min = Math.min(fromPosition, toPosition);
+        int max = Math.max(fromPosition, toPosition);
+        for(int i = min; i <= max; i++) {
+            if(i >= isHeaderByItemPosition.size()) {
+                isHeaderByItemPosition.add(null);
+            }
+        }
+
         if(fromPosition < toPosition) {
             if(fromPosition == 0) {
                 isHeaderByItemPosition.set(0, true);
@@ -160,14 +168,14 @@ public class HeaderStore {
         }
         else if(fromPosition > toPosition) {
             if(toPosition == 0) {
-              isHeaderByItemPosition.set(0, true);
+                isHeaderByItemPosition.set(0, true);
             }
             else {
-              long toPositionId = adapter.getHeaderId(toPosition);
-              long beforeToPositionId = adapter.getHeaderId(toPosition - 1);
-              long afterToPositionId = adapter.getHeaderId(toPosition + 1);
-              isHeaderByItemPosition.set(toPosition, toPositionId != beforeToPositionId);
-              isHeaderByItemPosition.set(toPosition + 1, toPositionId != afterToPositionId);
+                long toPositionId = adapter.getHeaderId(toPosition);
+                long beforeToPositionId = adapter.getHeaderId(toPosition - 1);
+                long afterToPositionId = adapter.getHeaderId(toPosition + 1);
+                isHeaderByItemPosition.set(toPosition, toPositionId != beforeToPositionId);
+                isHeaderByItemPosition.set(toPosition + 1, toPositionId != afterToPositionId);
             }
 
             long fromPositionId = adapter.getHeaderId(fromPosition);
@@ -175,8 +183,8 @@ public class HeaderStore {
             isHeaderByItemPosition.set(fromPosition, fromPositionId != beforeFromPositionId);
 
             if(fromPosition < isHeaderByItemPosition.size() - 1) {
-              long afterFromPositionId = adapter.getHeaderId(fromPosition + 1);
-              isHeaderByItemPosition.set(fromPosition + 1, fromPositionId != afterFromPositionId);
+                long afterFromPositionId = adapter.getHeaderId(fromPosition + 1);
+                isHeaderByItemPosition.set(fromPosition + 1, fromPositionId != afterFromPositionId);
             }
         }
         else {
@@ -198,6 +206,14 @@ public class HeaderStore {
 
     public void onItemRangeChanged(int startPosition, int itemCount) {
         headersViewByHeadersIds.clear();
+
+        if (startPosition + itemCount >= isHeaderByItemPosition.size()) {
+            for (int i = startPosition; i < startPosition + itemCount; i++) {
+                if(i >= isHeaderByItemPosition.size()) {
+                  isHeaderByItemPosition.add(null);
+                }
+            }
+        }
 
         for(int i = 0; i < itemCount; i ++) {
             isHeaderByItemPosition.set(i + startPosition, null);


### PR DESCRIPTION
There could be situations in `onItemRangeMoved` and `onItemRangeChanged` where `isHeaderByItemPosition` does not have the same size as the underlying adapter. This fix adds the indexes that are missing.
