### PR TITLE
notifyItemChanged causes ArrayIndexOutOfBoundsException

### DIFF
--- a/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/MainActivity.java
+++ b/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends ActionBarActivity implements OnHeaderClickList
         list.setLayoutManager(new LinearLayoutManager(MainActivity.this, LinearLayoutManager.VERTICAL, false));
 
         personDataProvider = new PersonDataProvider();
-        personAdapter = new PersonAdapter(personDataProvider);
+        personAdapter = new PersonAdapter(this, personDataProvider);
 
         top = new StickyHeadersBuilder()
                 .setAdapter(personAdapter)

--- a/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/adapters/PersonAdapter.java
+++ b/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/adapters/PersonAdapter.java
@@ -1,13 +1,19 @@
 package com.eowise.recyclerview.stickyheaders.samples.adapters;
 
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import com.eowise.recyclerview.stickyheaders.samples.R;
 import com.eowise.recyclerview.stickyheaders.samples.data.PersonDataProvider;
+import com.eowise.recyclerview.stickyheaders.samples.listeners.OnEditListener;
 import com.eowise.recyclerview.stickyheaders.samples.listeners.OnRemoveListener;
 
 import java.util.List;
@@ -15,12 +21,14 @@ import java.util.List;
 /**
  * Created by aurel on 22/09/14.
  */
-public class PersonAdapter extends RecyclerView.Adapter<PersonAdapter.ViewHolder> implements OnRemoveListener {
+public class PersonAdapter extends RecyclerView.Adapter<PersonAdapter.ViewHolder> implements OnRemoveListener, OnEditListener {
 
     private List<String> items;
     private PersonDataProvider personDataProvider;
+    private Context mContext;
 
-    public PersonAdapter(PersonDataProvider personDataProvider) {
+    public PersonAdapter(Context context, PersonDataProvider personDataProvider) {
+        this.mContext = context;
         this.personDataProvider = personDataProvider;
         this.items = personDataProvider.getItems();
 
@@ -55,23 +63,46 @@ public class PersonAdapter extends RecyclerView.Adapter<PersonAdapter.ViewHolder
         notifyItemRemoved(position);
     }
 
-    public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+    @Override
+    public void onEdit(final int position) {
+        final EditText edit = new EditText(mContext);
+        edit.setTextColor(Color.BLACK);
+        new AlertDialog.Builder(mContext).setTitle(R.string.edit).setView(edit).setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                String name = edit.getText().toString();
+                personDataProvider.update(position, name);
+                notifyItemChanged(position);
+            }
+        }).create().show();
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
 
         TextView label;
-        private OnRemoveListener listener;
+        private OnRemoveListener removeListener;
+        private OnEditListener editListener;
 
-        public ViewHolder(View itemView, OnRemoveListener listener) {
+        public ViewHolder(View itemView, PersonAdapter personAdapter) {
             super(itemView);
             this.label = (TextView) itemView.findViewById(R.id.name);
-            this.listener = listener;
+            this.removeListener = personAdapter;
+            this.editListener = personAdapter;
 
             itemView.setOnClickListener(this);
+            itemView.setOnLongClickListener(this);
         }
 
 
         @Override
         public void onClick(View v) {
-            listener.onRemove(getPosition());
+            removeListener.onRemove(getPosition());
+        }
+
+        @Override
+        public boolean onLongClick(View v) {
+            editListener.onEdit(getPosition());
+            return true;
         }
     }
 

--- a/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/data/PersonDataProvider.java
+++ b/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/data/PersonDataProvider.java
@@ -1,8 +1,6 @@
 package com.eowise.recyclerview.stickyheaders.samples.data;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -271,4 +269,7 @@ public class PersonDataProvider {
             "Yu Schilke"
     };
 
+    public void update(int position, String name) {
+        addedItems.set(position, name);
+    }
 }

--- a/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/listeners/OnEditListener.java
+++ b/samples/src/main/java/com/eowise/recyclerview/stickyheaders/samples/listeners/OnEditListener.java
@@ -1,0 +1,8 @@
+package com.eowise.recyclerview.stickyheaders.samples.listeners;
+
+/**
+ * Created by Robby on 1/27/2015.
+ */
+public interface OnEditListener {
+    public void onEdit(int position);
+}

--- a/samples/src/main/res/values/strings.xml
+++ b/samples/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Sticky headers Samples</string>
+    <string name="edit">Edit</string>
 
     <string-array name="samples">
         <item>Top</item>


### PR DESCRIPTION
Modifying an Adapter item and calling notifyItemChanged causes an ArrayIndexOutOfBoundsException.  The stacktrace is below. This pull request adds an edit (by long click) capability that can reproduce the issue.

Caused by: java.lang.ArrayIndexOutOfBoundsException: length=12; index=-1
       at java.util.ArrayList.set(ArrayList.java:483)
       at com.eowise.recyclerview.stickyheaders.HeaderStore.onItemRangeChanged(HeaderStore.java:219)
       at com.eowise.recyclerview.stickyheaders.StickyHeadersItemDecoration$AdapterDataObserver.onItemRangeChanged(StickyHeadersItemDecoration.java:140)
       at android.support.v7.widget.RecyclerView$AdapterDataObservable.notifyItemRangeChanged(RecyclerView.java:7503)
       at android.support.v7.widget.RecyclerView$Adapter.notifyItemChanged(RecyclerView.java:4353)
